### PR TITLE
Update transformers pin to resolve errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ pillow>=10.2.0
 torch>=2.4.0
 torchvision>=0.15.0
 numpy>=1.18.1
-transformers>=4.6.0
+transformers>=4.57
 fairscale>=0.4.0
 opencv-python>=4.5.0


### PR DESCRIPTION
Resolve this error Lily got
```
ImportError: cannot import name 'find_pruneable_heads_and_indices' from 'transformers.pytorch_utils' (/Users/lilyge/miniconda3/envs/pyserini/lib/python3.11/site-packages/transformers/pytorch_utils.py)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/lilyge/miniconda3/envs/pyserini/lib/python3.11/site-packages/pyserini/server/mcp/__main__.py", line 1, in <module>
    from pyserini.server.mcp.mcpyserini import main
  File "/Users/lilyge/miniconda3/envs/pyserini/lib/python3.11/site-packages/pyserini/server/mcp/mcpyserini.py", line 26, in <module>
    from pyserini.server.mcp.tools import register_tools
  File "/Users/lilyge/miniconda3/envs/pyserini/lib/python3.11/site-packages/pyserini/server/mcp/tools.py", line 28, in <module>
    from pyserini.server.search_controller import SearchController, DenseSearchResult
  File "/Users/lilyge/miniconda3/envs/pyserini/lib/python3.11/site-packages/pyserini/server/search_controller.py", line 32, in <module>
    from pyserini.encode.optional._uniir import UniIRQueryEncoder
  File "/Users/lilyge/miniconda3/envs/pyserini/lib/python3.11/site-packages/pyserini/encode/optional/_uniir.py", line 20, in <module>
    from uniir_for_pyserini.pyserini_integration.uniir_corpus_encoder import CorpusEncoder
  File "/Users/lilyge/miniconda3/envs/pyserini/lib/python3.11/site-packages/uniir_for_pyserini/pyserini_integration/uniir_corpus_encoder.py", line 5, in <module>
    from uniir_for_pyserini.pyserini_integration.uniir_base_encoder import UniIRBaseEncoder
  File "/Users/lilyge/miniconda3/envs/pyserini/lib/python3.11/site-packages/uniir_for_pyserini/pyserini_integration/uniir_base_encoder.py", line 10, in <module>
    from uniir_for_pyserini.models.uniir_blip.blip_featurefusion.blip_ff import BLIPFeatureFusion
  File "/Users/lilyge/miniconda3/envs/pyserini/lib/python3.11/site-packages/uniir_for_pyserini/models/uniir_blip/blip_featurefusion/blip_ff.py", line 1, in <module>
    from uniir_for_pyserini.models.uniir_blip.backbone.med import BertConfig, BertModel
  File "/Users/lilyge/miniconda3/envs/pyserini/lib/python3.11/site-packages/uniir_for_pyserini/models/uniir_blip/backbone/med.py", line 46, in <module>
    from transformers.modeling_utils import (
ImportError: cannot import name 'apply_chunking_to_forward' from 'transformers.modeling_utils' (/Users/lilyge/miniconda3/envs/pyserini/lib/python3.11/site-packages/transformers/modeling_utils.py)
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```